### PR TITLE
Jonstokes js di context

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ The original repo seems to be lacking in activity and the maintainers have not r
 (with some of the PRs going back to 2017!). 
 We needed this _so much_ to organise our code at Zomato, and since waiting was not an option, Vive la Open Source!
 
-Some of the pending PRs in the original have been merged here already:
-- thejspr:patch-1
-- joevandyk:patch-1
+Some of the pending PRs and branches in the original have been merged here already:
+- thejspr:patch-1 (https://github.com/collectiveidea/interactor/pull/158)
+- joevandyk:patch-1 (https://github.com/collectiveidea/interactor/pull/168)
+- v4
+- jonstokes:js-di-context (via local branch jonstokes-js-di-context) 
  
 If the original repo comes alive again, this one will be deprecated. :)
 
@@ -28,6 +30,8 @@ Add Interactor to your Gemfile and `bundle install`.
 ```ruby
 gem "interactor", "~> 4.0"
 ```
+
+---
 
 ## What is an Interactor?
 
@@ -60,6 +64,8 @@ To define an interactor, simply create a class that includes the `Interactor`
 module and give it a `call` instance method. The interactor can access its
 `context` from within `call`.
 
+---
+
 ### Context
 
 An interactor is given a *context*. The context contains everything the
@@ -69,11 +75,15 @@ When an interactor does its single purpose, it affects its given context.
 
 #### Adding to the Context
 
-As an interactor runs it can add information to the context.
+As an interactor runs it can add information to the context. 
 
 ```ruby
 context.user = user
 ```
+
+The context uses `OpenStruct` internally, so it may be slow for your use.
+Additionally a non existent method will return `nil`.  
+If this is inconvenient, You can override this with a PORO. _See ["Custom Context"](#custom-context)_.
 
 #### Failing the Context
 
@@ -121,6 +131,28 @@ Normally, however, these exceptions are not seen. In the recommended usage, the 
 This works because the `call` class method swallows these exceptions.  When unit testing an interactor, if calling custom business logic methods directly and bypassing `call`, be aware that `fail!` will generate such exceptions.
 
 See *Interactors in the Controller*, below, for the recommended usage of `call` and `success?`.
+
+#### Custom Context
+
+You can also use a custom context class using the class method `:with_context_class`.
+
+```ruby
+class MyContext
+  include Interactor::ContextBehaviour  # include this to get the default context behaviour
+  
+  # custom behaviour here
+end
+
+class AuthenticateUser
+  include Interactor
+  
+  with_context_class MyContext
+   
+   # interactor behaviour here
+end
+```
+
+---
 
 ### Hooks
 
@@ -255,6 +287,8 @@ module InteractorTimer
 end
 ```
 
+---
+
 ## Interactors in the Controller
 
 Most of the time, your application will use its interactors from its
@@ -338,6 +372,8 @@ end
 For such a simple use case, using an interactor can actually require *more*
 code. So why use an interactor?
 
+---
+
 ### Clarity
 
 [We](http://collectiveidea.com) often use interactors right off the bat for all
@@ -383,6 +419,8 @@ If instead you use an interactor right away, as responsibilities are added, your
 controller (and its tests) change very little or not at all. Choosing the right
 kind of interactor can also prevent simply shifting those added responsibilities
 to the interactor.
+
+---
 
 ## Kinds of Interactors
 

--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -76,7 +76,9 @@ module Interactor
       new(context).tap(&:run!).context
     end
 
-    def context_with(klass)
+    # Public: Sets the context class to use instead of the default "Interactor::Context" class.
+    # This is useful if you want to set a more lightweight context object, or one with specialized behaviour.
+    def with_context_class(klass)
       @context_class = klass
     end
 

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -29,7 +29,7 @@ module Interactor
   #   context
   #   # => #<Interactor::Context foo="baz" hello="world">
 
-  module CommonContext
+  module ContextBehaviour
     module ClassMethods
       # Internal: Initialize an Interactor::Context or preserve an existing one.
       # If the argument given is an Interactor::Context, the argument is returned.
@@ -187,6 +187,6 @@ module Interactor
   end
 
   class Context < OpenStruct
-    include CommonContext
+    include ContextBehaviour
   end
 end


### PR DESCRIPTION
From the original PR 
https://github.com/collectiveidea/interactor/pull/149

> To me, the context object is by far the weakest part of this gem. First, OpenStruct is notoriously slow, and everyone avoids it if they can. A PORO would be way faster.
> 
> But an even bigger deal is the lack of support for contracts, which most of these actor-type gems have nowadays.
> 
> This PR, though it's admittedly not fully baked and offered here mainly for feedback, is a very small tweak that lets you declare your own context class inside your interactor.
> 
> ```ruby
> class PostContext
>   include Interactor::CommonContext
>   attr_accessor :title, :description, :author
>   
>   def initialize(attrs)
>     validate_attrs(attrs)
>     update(attrs)
>   end
> 
>   def update(attrs)
>     attrs.each { |k, v| self.send("#{k}=", v) }
>   end
> 
>   def validate_attrs(attrs)
>     raise "Missing title!" unless attrs[:title]
>   end
> end
> 
> class CreatePost
>   include Interactor
> 
>   context_with PostContext
> 
>   def call
>     # do stuff
>   end
> end
> 
> create_post = CreatePost.call(title: "Foo", description: "Bar", author: current_user) # works just like normal!
> ```
> 
> The above isn't supposed to be real code -- that `PostContext` object needs to return itself when you call `#modifiable` on it, and it should support the `[], []=` interface, and a few other things related to the fact that the gem expects an `OpenStruct`, but you get the idea.
> 
> You can declare a PORO and do your own validation of the context however you like -- go nuts and use `ActiveRecord::Validations` or the `reform` gem or `dry-validation`, or whatever you like to impose a strict shape on the context. This way, the context object is no longer required to be magical and slow.
> 
> Thoughts?